### PR TITLE
Support for single and double quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,22 @@ with one running node process. Cliffy is NOT an argv parser.
 This is what allows Cliffy to parse negatives.
 - Requires node v6+
 
+### Quoted parameters
+
+Parameters may be quoted using either ' (single) or " (double) quotes. For example the command could be
+
+```
+say "Hello World" 'Lovely Weather'
+```
+
+This would give two parameters of `Hello World` and `Lovely Weather`.  When inside the quoted parameter, the other type of quotes can be used. This lets JSON be entered for example.
+
+```
+say '{"text": "This is the weather"}'
+```
+
+Will give a parameter of the string, `{"text": "This is the weather"}` that can then be parsed as JSON.
+
 ## Quickstart
 
 **Installation**:

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,8 +57,9 @@ export class CLI {
     }
 
     private async executeCommand(input: string): Promise<void> {
-        const parts = input.match(/(\w|@|-|\.)+|"[^"]+"/g) || [];
-        const pieces = parts.map(word => word.replace(/^"(.+(?="$))"$/, '$1'));
+        const parts = input.match(/(\w|@|-|\.)+|"[^"]+"|'[^']+'/g) || [];
+        const pieces = parts.map(word => word.replace(/^"(.+(?="$))"$/, '$1')).
+                             map(word => word.replace(/^'(.+(?='$))'$/, '$1'));
 
         if (pieces[0] === "help") return this.help(pieces.slice(1));
 

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -79,6 +79,35 @@ describe("CLI", function() {
         });
     });
 
+    it("Should accept single and double quoted parameters", function() {
+        return new Promise((res, rej) => {
+            cli.addCommand("test", {
+                parameters: [
+                    { label: "p1", type: "string" },
+                    { label: "p2", type: "string" }],
+                action(params) {
+                    const correct = params.p1 === "hello \"quoted\" world" && params.p2 === "lovely 'quoted' weather";
+                    if (correct) { res(); } else { rej(new Error("Bad params")); }
+                }
+            });
+            send("test 'hello \"quoted\" world' \"lovely 'quoted' weather\"");
+        });
+    });
+    it("Should accept json-style parameters", function() {
+        return new Promise((res, rej) => {
+            cli.addCommand("test", {
+                parameters: [
+                    { label: "p1", type: "string" }],
+                action(params) {
+                    const correct = params.p1 === "{\"text\":\"This is the weather\"}";
+                    if (correct) { res(); } else { rej(new Error("Bad params")); }
+                }
+            });
+            const testJson = JSON.stringify({text:"This is the weather"});
+            send(`test '${testJson}'`);
+        });
+    });
+
     it("Should throw an error on invalid optional parameter order", function() {
         try {
             cli.addCommand("test", {


### PR DESCRIPTION
Hope that this is ok!  Thanks!

Added support for single and double quotes.
Tests for simple case, and the case where JSON is used.
Updated README.md

Signed-off-by: Matthew B. White <whitemat@uk.ibm.com>