### PR TITLE
Option to not display help if a blank line is entered

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,9 @@ Interface:
 class CLI {
     constructor(opts: {
         input?: NodeJS.ReadableStream,
-        output?: NodeJS.WritableStream
+        output?: NodeJS.WritableStream,
+         /** Set to true to prevent cliffy from displaying help text after entering a blank line. Defaults to false */
+        quietBlank?: boolean
     } = {})
 }
 ```
@@ -162,7 +164,7 @@ Usage:
 ```typescript
 const cli = new CLI(opts)
 ```
-
+  
 ### `cli.addCommand(name: string, command: Command): this`
 
 Register a command

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,15 +16,18 @@ export class CLI {
     private name?: string;
     private info?: string;
     private version?: string;
+    private quietBlank: boolean;
 
     constructor(opts: {
         input?: NodeJS.ReadableStream,
-        output?: NodeJS.WritableStream
+        output?: NodeJS.WritableStream,
+        quietBlank?: boolean,
     } = {}) {
         const input = opts.input || process.stdin;
         const output = opts.output || process.stdout;
         this.readline = readline.createInterface(input, output);
         this.readline.pause();
+        this.quietBlank = opts.quietBlank || false;
     }
 
     private paramIsRequired(param: Parameter | string) {
@@ -64,6 +67,7 @@ export class CLI {
         if (pieces[0] === "help") return this.help(pieces.slice(1));
 
         const parsedCmd = findPromptedCommand(pieces, this.cmds);
+        if (!parsedCmd && this.quietBlank) return;
         if (!parsedCmd) return this.invalidCommand();
 
         const options = parseOptions(parsedCmd.command, parsedCmd.remainingPieces);


### PR DESCRIPTION
Mnay CLIs eg bash/zsh, accept an empty line as input without error. People will
separate out commands to make reading easier.

This PR adds an option to enable any blank input to be ignored. Default is the existing
behaviour where the help is displayed.


@drew-y hope this PR is ok with you;  admit I couldn't think of a better option name!

Signed-off-by: Matthew B White <whitemat@uk.ibm.com>